### PR TITLE
is.touchDevice()

### DIFF
--- a/is.js
+++ b/is.js
@@ -681,6 +681,14 @@
         is.offline = not(is.online);
         // offline method does not support 'all' and 'any' interfaces
         is.offline.api = ['not'];
+
+        // is a touch device ?
+        is.touchDevice = function() {
+            return(
+              ('ontouchstart' in window) ||
+              ('DocumentTouch' in window. && document instanceof DocumentTouch)
+            );
+        };
     }
 
     // Object checks


### PR DESCRIPTION
Browser agnostic test to detect if current device is a touch device or
is an hybrid device in "touch mode".
Useful to condition a Swipe, for example.
